### PR TITLE
Use the first X-Forwarded-For ip when they are all potential proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ if 'X-Forwarded-For' not in headers:
 forwarded_ips = whitespace stripped, split by ',' of X-Forwarded-For header
 
 look from the right of forwarded_ips, find the first ip that is not in the
-proxy ips.  The first one found is the ip to set
+proxy ips.  The first one found is the ip to set.  If all ips in
+X-Forwarded-For are proxy ips, the leftmost one is set.
 
 If none are found:
     return

--- a/tests/wsgi_mod_rpaf_test.py
+++ b/tests/wsgi_mod_rpaf_test.py
@@ -78,4 +78,14 @@ def test_x_forwarded_for_is_all_proxy_ips(wrapped_app):
         REMOTE_ADDR: str('127.0.0.1'),
         HTTP_X_FORWARDED_FOR: str('10.1.2.3, 127.0.0.1'),
     }
+    # mod-rpaf sets this to the last proxy ip, *not* remote_addr.  See #1
+    assert wrapped_app.get('/', extra_environ=environ).body == b'10.1.2.3'
+
+
+def test_x_forwarded_for_all_garbage(wrapped_app):
+    """Shouldn't ever happen, but it is a reasonable test"""
+    environ = {
+        REMOTE_ADDR: str('127.0.0.1'),
+        HTTP_X_FORWARDED_FOR: str('such, garbage'),
+    }
     assert wrapped_app.get('/', extra_environ=environ).body == b'127.0.0.1'

--- a/wsgi_mod_rpaf.py
+++ b/wsgi_mod_rpaf.py
@@ -64,13 +64,17 @@ def _rewrite_environ(environ, networks):
     environ = dict(environ)
     x_forwarded_for = wsgi_to_text(environ['HTTP_X_FORWARDED_FOR'])
     # Search from the end for the first ip which is not a proxy ip
+    ip_to_set = None
     for ip in x_forwarded_for.split(',')[::-1]:
         ip = _safe_parse_ip(ip.strip())
         if _ip_in_networks(ip, networks):
+            ip_to_set = ip
             continue
         elif ip is not UNPARSEABLE_IP:
-            environ[str('REMOTE_ADDR')] = text_to_wsgi(six.text_type(ip))
+            ip_to_set = ip
             break
+    if ip_to_set is not None:
+        environ[str('REMOTE_ADDR')] = text_to_wsgi(six.text_type(ip_to_set))
     return environ
 
 


### PR DESCRIPTION
Resolves #1

Also added an additional testcase to cover when ip is *never* set, despite passing all the other checks