### PR TITLE
Remove [testenv:venv] now that `tox --devenv` is a thing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,5 @@ commands =
     pre-commit install -f --install-hooks
     pre-commit run --all-files
 
-[testenv:venv]
-envdir = venv
-commands =
-
 [pep8]
 ignore = E265,E501,W504


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos